### PR TITLE
Remove incorrect warning.

### DIFF
--- a/docs/http-https-probe.md
+++ b/docs/http-https-probe.md
@@ -22,13 +22,4 @@ The HTTPS probe (that is, where a target host is configured to use `https://` pr
 
 A valid HTTPS request on resources with custom certificates will require you to provide the CA certificate to the probe. By default, any certs stored in `/etc/ssl/certs/ca-certificates.crt` will be used to validate the connection.
 
-> [!WARNING]  
-> `wait-for`'s container does not come with any certificates. You must bring your own:
-> ```
-> docker run --rm \
->   -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates:ro \
->   ghcr.io/patrickdappollonio/wait-for:v1.2.0 \
->   --host https://google.com \
->   --verbose
-> ```
-> The example above mounts the local machine's certificate authorities inside the container.
+Currently, the Container image ships with the certificates found in [ca-certificates.crt](../extras/ca-certificates.crt).


### PR DESCRIPTION
Now that we ship certs by default, this warning is no longer valid.